### PR TITLE
Review app example gets now executed on every push on a PR

### DIFF
--- a/example-workflows/review-app.yaml
+++ b/example-workflows/review-app.yaml
@@ -10,7 +10,7 @@ jobs:
   review_app:
     runs-on: ubuntu-latest
     # only run when a pull request is opened
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     steps:
       - name: Cloning repo
         uses: actions/checkout@v4
@@ -23,6 +23,10 @@ jobs:
           # create a review app
           command: review-apps:create
           git_remote_url: 'ssh://dokku@dokku.me:22/appname'
+          # specify `--force` as a flag for git pushes
+          git_push_flags: '--force'
+          # specify the name of the branch, in cas you do not use master
+          # branch: main
           # specify a name for the review app
           review_app_name: review-appname-${{ github.event.pull_request.number }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/example-workflows/review-app.yaml
+++ b/example-workflows/review-app.yaml
@@ -23,10 +23,6 @@ jobs:
           # create a review app
           command: review-apps:create
           git_remote_url: 'ssh://dokku@dokku.me:22/appname'
-          # specify `--force` as a flag for git pushes
-          git_push_flags: '--force'
-          # specify the name of the branch, in cas you do not use master
-          # branch: main
           # specify a name for the review app
           review_app_name: review-appname-${{ github.event.pull_request.number }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Updated the review_app example, so it gets executed on each push.
Also added the `--force` to the example, because we do expect git to not be able to fast forward, 
and this will make sure the task does not fail.

Finally, bonus track, added (commented out so we stay true to the example spirit), how to overwrite the deploy branch. A classic is to use `main` instead of `master`, so we have it there.